### PR TITLE
APIへのリクエストをサーバサイドに移管する

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-PROMPT_TEMPLATE_DOMAIN=manage-opendata-bridge.dx-junkyard.com

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -38,7 +38,7 @@ export async function POST(req: Request) {
 }
 
 const readStream = async (
-  reader: ReadableStreamDefaultReader<string | undefined>,
+  reader: ReadableStreamDefaultReader,
   writer: WritableStreamDefaultWriter
 ) => {
   while (1) {

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,10 +1,3 @@
-import {
-  ReadableStreamDefaultReader,
-  TextDecoderStream,
-  TransformStream,
-  WritableStreamDefaultWriter,
-} from 'stream/web';
-
 const chatUrl = `${process.env.CHAT_API || ''}/chat`;
 
 export async function POST(req: Request) {
@@ -34,6 +27,7 @@ export async function POST(req: Request) {
   // 非同期で実行する
   readStream(reader, writer);
 
+  // @ts-ignore
   return new Response(responseStream.readable, {
     headers: {
       'Content-Type': 'text/event-stream',
@@ -44,7 +38,7 @@ export async function POST(req: Request) {
 }
 
 const readStream = async (
-  reader: ReadableStreamDefaultReader,
+  reader: ReadableStreamDefaultReader<string | undefined>,
   writer: WritableStreamDefaultWriter
 ) => {
   while (1) {

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,0 +1,59 @@
+import {
+  ReadableStreamDefaultReader,
+  TextDecoderStream,
+  TransformStream,
+  WritableStreamDefaultWriter,
+} from 'stream/web';
+
+const chatUrl = `${process.env.CHAT_API || ''}/chat`;
+
+export async function POST(req: Request) {
+  console.info('POST ' + req.url);
+
+  // レスポンス用のストリームを作成
+  const responseStream = new TransformStream();
+  const writer = responseStream.writable.getWriter();
+
+  // リクエストをchat-apiに転送
+  const formData = await req.formData();
+  const response = await fetch(chatUrl, {
+    method: 'POST',
+    body: formData,
+  });
+
+  const reader = response?.body
+    ?.pipeThrough(new TextDecoderStream())
+    .getReader();
+
+  if (!reader) {
+    return new Response('Internal Server Error', {
+      status: 500,
+    });
+  }
+
+  // 非同期で実行する
+  readStream(reader, writer);
+
+  return new Response(responseStream.readable, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      Connection: 'keep-alive',
+      'Cache-Control': 'no-cache, no-transform',
+    },
+  });
+}
+
+const readStream = async (
+  reader: ReadableStreamDefaultReader,
+  writer: WritableStreamDefaultWriter
+) => {
+  while (1) {
+    const { value, done } = await reader.read();
+    if (done) {
+      await writer.close();
+      break;
+    } else {
+      await writer.write(value);
+    }
+  }
+};

--- a/src/hooks/use-input-prompt.ts
+++ b/src/hooks/use-input-prompt.ts
@@ -31,11 +31,7 @@ const postActionUseRecipe = async (
   body.append('extension', arg.file.name.split('.').at(-1) || '');
   body.append('uuid', arg.uuid);
 
-  const chatUrl = `${process.env.NEXT_PUBLIC_CHAT_API || ''}/chat`;
-
-  console.log(chatUrl);
-
-  const response = await fetch(chatUrl, {
+  const response = await fetch('/api/chat', {
     method: 'POST',
     body,
   });

--- a/src/hooks/use-input-prompt.ts
+++ b/src/hooks/use-input-prompt.ts
@@ -70,12 +70,16 @@ const postActionUseRecipe = async (
     const output = await fetch('/api/asset/' + arg.uuid).then((res) =>
       res.text()
     );
-    const csvData = parse(output, { columns: true });
-    arg.setOutput({
-      name: 'output.csv',
-      content: csvData,
-      raw: output,
-    } as CsvFile);
+    try {
+      const csvData = parse(output, { columns: true });
+      arg.setOutput({
+        name: 'output.csv',
+        content: csvData,
+        raw: output,
+      } as CsvFile);
+    } catch (e) {
+      console.error(e);
+    }
   }
 };
 


### PR DESCRIPTION
close #94 

参考
https://zenn.dev/t_yng/scraps/13d795d1b0b875
https://medium.com/@david.richards.tech/sse-server-sent-events-using-a-post-request-without-eventsource-1c0bd6f14425